### PR TITLE
feat: 소방서 관할 내 화재 위험 건물 조회 API 구현

### DIFF
--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -19,5 +19,5 @@ async def route_chat(req: ChatRequest):
     """
     if not req.query or not req.query.strip():
         raise HTTPException(status_code=400, detail="query는 비어 있을 수 없습니다.")
-    fn_no, data = call_llm_and_route(req.query)
+    fn_no, data = await call_llm_and_route(req.query)
     return {"functionNo": fn_no, "data": data}

--- a/backend/app/api/endpoints/fire_patrol.py
+++ b/backend/app/api/endpoints/fire_patrol.py
@@ -1,26 +1,15 @@
-"""
-GET /patrol/buildings  화재 취약 건물 7곳의 메타데이터를 그대로 반환
-"""
-
-from fastapi import APIRouter
-
+from fastapi import APIRouter, Query
 from ...schemas.building import Building
-from ...services.patrol_service import get_all_buildings
+from ...services.building_service import get_buildings_by_station
 
-# prefix="/patrol" 은 app/api/router.py 에서 부여됩니다.
 router = APIRouter()
 
-# -----------------------------------------------------------------
-# 단일 엔드포인트:  GET /patrol/buildings
-# -----------------------------------------------------------------
 @router.get(
     "/buildings",
-    summary="화재 위험 건물 메타데이터 7곳 조회",
-    response_model=list[Building],   # Swagger에 배열 구조로 표시
+    response_model=list[Building],
+    summary="소방서 관할 화재 취약 건물 조회",
 )
-def list_buildings() -> list[Building]:
-    """
-    ▶ 별다른 파라미터 없이 호출 가능한 **GET** 엔드포인트
-    ▶ 서비스 계층에서 하드코딩 데이터를 읽어 그대로 반환합니다.
-    """
-    return get_all_buildings()
+async def list_buildings(
+        station: str = Query("종로소방서", description="소방서 이름")
+) -> list[Building]:
+    return await get_buildings_by_station(station)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,6 +19,7 @@ class Settings:
     DB_URL: str | None = os.getenv("DB_URL")          # 예) mysql+asyncmy://user:pass@host/db
     OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY")
     OPENAI_MODEL: str = os.getenv("OPENAI_MODEL", "gpt-4o")
+    VWORLD_KEY = os.getenv("VWORLD_KEY")
 
 settings = Settings()
 

--- a/backend/app/schemas/building.py
+++ b/backend/app/schemas/building.py
@@ -1,26 +1,38 @@
-"""
-▶ Building = Location + 건축물대장 주요 필드를 확장한 모델
-"""
-
 from typing import Optional
+
 from pydantic import Field
 
 from .location import Location
 
-class Building(Location):
-    # ------------------------------
-    # 순찰 경로용 메타데이터
-    # ------------------------------
-    seq: Optional[int] = Field(
-        None,
-        description="경로 상 방문 순서 (1부터). 서비스 계산 뒤 세팅."
-    )
 
-    # ------------------------------
-    # 건축물대장(getBrRecapTitleInfo) 주요 필드
-    # ------------------------------
-    platPlc: str      = Field(..., description="지번 주소")
-    newPlatPlc: str   = Field(..., description="도로명 주소")
-    strctCdNm: str    = Field(..., description="주 구조(예: 목조)")
-    useAprDay: str    = Field(..., description="사용 승인일 (YYYY-MM-DD)")
-    totArea: float    = Field(..., description="연면적(㎡)")
+class Building(Location):
+    """
+    Location( name · lat · lon ) + 건축물대장 주요 필드 + 위험도
+    """
+
+    # --- 주소 ---
+    platPlc: str = Field(..., description="지번 주소")
+    newPlatPlc: str = Field(..., description="도로명 주소")
+
+    # --- 건물 식별·용도·구조 ---
+    buldId: Optional[str] = Field(
+        None, description="건물 식별번호(건축물대장 buld_idntfc_no)"
+    )
+    buldKndCode: Optional[str] = Field(
+        None, description="건물 종류 코드(단독·공장·교육 등)"
+    )
+    mainPrposCode: Optional[str] = Field(
+        None, description="주용도 코드"
+    )
+    strctCdNm: str = Field(..., description="주 구조(예: 철근콘크리트구조)")
+
+    # --- 연식·규모 ---
+    useAprDay: str = Field(..., description="준공/사용승인일(YYYY-MM-DD)")
+    totArea: float = Field(..., description="연면적(㎡)")
+    groundFloors: int = Field(..., alias="grndFloors", description="지상 층수")
+    bsmFloors: int = Field(..., alias="bsmFloors", description="지하 층수")
+
+    # --- 위험도 ---
+    riskScore: int = Field(
+        ..., ge=0, le=99, description="화재 취약도(0~99)"
+    )

--- a/backend/app/services/building_service.py
+++ b/backend/app/services/building_service.py
@@ -1,0 +1,137 @@
+"""
+소방서 → 관할 건물 목록 + 위험도 계산 서비스
+──────────────────────────────────────────
+1) 관할 폴리곤(lt_c_usfsffb) → 타일링
+2) 각 타일과 dt_d162 레이어 INTERSECTS 조회(WFS 1.1.0 JSON)
+3) 위험도(score) 계산 → riskScore 내림차순 상위 200건 반환
+※ 모든 필드 변환·파싱을 안전 함수로 감싸 None/빈값 오류 방지
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List, Tuple, Optional
+
+import httpx
+
+from ..schemas.building import Building
+from .fire_risk import score
+from .vworld import fire_zone_url, bldginfo_url, split_bbox, fetch_json
+
+
+# ───────────────────────────────────────────────
+# 안전 변환 헬퍼
+# ───────────────────────────────────────────────
+def _safe_str(v: object | None, default: str = "") -> str:
+    return str(v) if v not in (None, "") else default
+
+
+def _safe_int(v: object | None, default: int = 0) -> int:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_float(v: object | None, default: float = 0.0) -> float:
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return default
+
+
+# ───────────────────────────────────────────────
+# geometry → 대표 lon/lat 추출
+# ───────────────────────────────────────────────
+def _lonlat(geom: dict) -> Optional[Tuple[float, float]]:
+    gtype = geom.get("type")
+    coords = geom.get("coordinates")
+
+    if not coords:
+        return None
+
+    try:
+        if gtype == "Point":
+            lon, lat = coords[:2]
+        elif gtype == "Polygon":
+            lon, lat = coords[0][0][:2]
+        elif gtype == "MultiPolygon":
+            lon, lat = coords[0][0][0][:2]
+        else:
+            return None
+        return lon, lat
+    except (IndexError, TypeError):
+        return None
+
+
+# ───────────────────────────────────────────────
+# public 함수 : 엔드포인트에서 호출
+# ───────────────────────────────────────────────
+async def get_buildings_by_station(station: str) -> List[Building]:
+    """
+    Parameters
+    ----------
+    station : '종로소방서', '구로소방서' …  (소방서명 전체)
+
+    Returns
+    -------
+    List[Building]  (riskScore desc, max 200)
+    """
+    async with httpx.AsyncClient() as client:
+        # ① 관할 폴리곤 GeoJSON
+        zone_geo = await fetch_json(fire_zone_url(station), client)
+        geom = zone_geo["features"][0]["geometry"]
+
+        ring = (
+            geom["coordinates"][0] if geom["type"] == "Polygon"
+            else geom["coordinates"][0][0]
+        )
+        poly_coords = [(pt[0], pt[1]) for pt in ring]   # (lon,lat)
+
+        # ② 타일링 후 병렬로 dt_d162 조회
+        tasks = [fetch_json(bldginfo_url(tile), client)
+                 for tile in split_bbox(poly_coords)]
+        pages = await asyncio.gather(*tasks)
+
+    # ③ 병합 + 위험도
+    buildings: list[Building] = []
+    for page in pages:
+        for feat in page.get("features", []):
+            ll = _lonlat(feat["geometry"])
+            if ll is None:        # 좌표 추출 실패 → skip
+                continue
+
+            prop = feat["properties"]
+
+            buildings.append(
+                Building(
+                    # 기본 위치·이름
+                    name      = _safe_str(prop.get("buld_nm"), "건물"),
+                    lon       = ll[0],
+                    lat       = ll[1],
+
+                    # 주소 (dt_d162 에는 상세 주소 없음)
+                    platPlc   = "-",
+                    newPlatPlc= "-",
+
+                    # 구조·규모·연식
+                    strctCdNm   = _safe_str(prop.get("strct_code")),
+                    useAprDay   = _safe_str(prop.get("prmisn_de") or
+                                            prop.get("use_confm_de"))[:8],
+                    totArea     = _safe_float(prop.get("buld_totar")),
+                    grndFloors  = _safe_int(prop.get("ground_floor_co")),
+                    bsmFloors   = _safe_int(prop.get("undgrnd_floor_co")),
+
+                    # 식별 코드
+                    buldId        = _safe_str(prop.get("buld_idntfc_no")),
+                    buldKndCode   = _safe_str(prop.get("buld_knd_code")),
+                    mainPrposCode = _safe_str(prop.get("main_prpos_code")),
+
+                    # 위험도
+                    riskScore = score(prop),
+                )
+            )
+
+    # ④ 위험도 높은 순 정렬 → 상위 200건만
+    buildings.sort(key=lambda b: b.riskScore, reverse=True)
+    return buildings[:200]

--- a/backend/app/services/features.py
+++ b/backend/app/services/features.py
@@ -1,4 +1,5 @@
 from typing import Dict, Any
+from .building_service import get_buildings_by_station
 
 def feature_1_visualization(query: str) -> Dict[str, Any]:
     return {"message": f"1번 기능 호출, 입력 쿼리: {query}"}
@@ -8,8 +9,15 @@ def feature_2_doc_pdf(query: str) -> Dict[str, Any]:
     return {"message": f"2번 기능 호출, 입력 쿼리: {query}"}
 
 
-def feature_3_map_predict(query: str) -> Dict[str, Any]:
-    return {"message": f"3번 기능 호출, 입력 쿼리: {query}"}
+async def feature_3_map_predict(query: str) -> Dict[str, Any]:
+    """
+    예) '종로 소방서 화재 예측 지도 그려줘' → station='종로소방서'
+    간단 문자열 파싱만(공백 제거) 적용
+    """
+    station = query.split(" ")[0].replace(" ", "")
+    data = await get_buildings_by_station(station)
+    # pydantic 모델 → dict 로 시리얼라이즈
+    return {"station": station, "buildings": [b.dict(by_alias=True) for b in data]}
 
 
 def feature_4_general_chat(query: str) -> Dict[str, Any]:

--- a/backend/app/services/fire_risk.py
+++ b/backend/app/services/fire_risk.py
@@ -1,0 +1,76 @@
+"""
+위험도 산정 v3 – 시그모이드 기반
+────────────────────────────────
+0~99 분포를 확보하면서도 화재학적으로 논리적 근거를 유지
+"""
+
+from math import log, exp
+from datetime import datetime
+
+THIS_YEAR = datetime.now().year
+
+
+# ──────────────────────────────────
+# 안전 변환 헬퍼
+# ──────────────────────────────────
+def _safe_int(v, d=0):
+    try: return int(v)
+    except (TypeError, ValueError): return d
+
+def _safe_float(v, d=0.0):
+    try: return float(v)
+    except (TypeError, ValueError): return d
+
+
+# ──────────────────────────────────
+# S‑커브 변환 함수
+# ──────────────────────────────────
+def _sigmoid(x: float, mid: float, scale: float) -> float:
+    """
+    값이 mid 에서 0.5, scale 은 기울기(작을수록 급격)
+    반환 범위 0.0 ~ 1.0
+    """
+    return 1.0 / (1.0 + exp(-(x - mid) / scale))
+
+
+# ──────────────────────────────────
+# 위험도 계산
+# ──────────────────────────────────
+def score(prop: dict) -> int:
+    # ---------- 1) 발생 가능성 P ----------
+    # (a) 노후도
+    year = _safe_int((prop.get("prmisn_de") or "")[:4], 1970)
+    age  = max(0, THIS_YEAR - year)
+    age_norm = _sigmoid(age, mid=35, scale=7)   # 35년 = 0.5
+
+    # (b) 가연성 구조
+    combust_map = {"10": 1.0, "20": 0.95, "21": 0.9, "30": 0.7,
+                   "40": 0.4, "42": 0.3}          # 42=철근콘크리트
+    strct = str(prop.get("strct_code") or "")[:2]
+    combust_norm = combust_map.get(strct, 0.25)  # 기본 0.25
+
+    P = 0.6 * age_norm + 0.4 * combust_norm      # 0 ~ 1
+
+    # ---------- 2) 피해 규모 C ----------
+    # (a) 층수
+    floors = _safe_int(prop.get("ground_floor_co"))
+    floors_norm = _sigmoid(floors, mid=6, scale=1.8)  # 6층=0.5
+
+    # (b) 연면적(로그)
+    area = max(1.0, _safe_float(prop.get("buld_totar")))
+    area_norm = _sigmoid(log(area), mid=log(3000), scale=0.6)
+
+    # (c) 다중이용
+    multi_use = str(prop.get("main_prpos_code") or "")
+    if multi_use in {"04000","15000","17000","21000","22000","23000"}:
+        usage_norm = 1.0
+    elif multi_use in {"03000","09000","18000","20000"}:  # 업무·공장 등
+        usage_norm = 0.4
+    else:
+        usage_norm = 0.1
+
+    C = 0.45 * floors_norm + 0.35 * area_norm + 0.20 * usage_norm
+
+    # ---------- 3) 최종 위험도 ----------
+    risk = int(round(100 * P * C))          # 0 ~ 100
+    return min(max(risk, 0), 99)

--- a/backend/app/services/function_caller.py
+++ b/backend/app/services/function_caller.py
@@ -13,7 +13,7 @@ from .features import (
 
 client = OpenAI(api_key=settings.OPENAI_API_KEY)
 
-def call_llm_and_route(query: str):
+async def call_llm_and_route(query: str):
     chat_resp = client.chat.completions.create(
         model=settings.OPENAI_MODEL,
         temperature=0,
@@ -43,6 +43,7 @@ def call_llm_and_route(query: str):
     elif tool_name == "generate_official_doc_pdf":
         return int(FeatureID.DOC_PDF), feature_2_doc_pdf(user_query)
     elif tool_name == "predict_fire_risk_map":
-        return int(FeatureID.MAP_PREDICT), feature_3_map_predict(user_query)
+        data = await feature_3_map_predict(user_query)    # ← await
+        return int(FeatureID.MAP_PREDICT), data
     else:
         return int(FeatureID.GENERAL_CHAT), feature_4_general_chat(user_query)

--- a/backend/app/services/vworld.py
+++ b/backend/app/services/vworld.py
@@ -1,0 +1,100 @@
+"""
+V‑World WFS 헬퍼 모듈
+────────────────────────────
+* 소방서 관할 폴리곤(lt_c_usfsffb) → 건물 레이어(dt_d162) 교차 조회
+* dt_d162 는 WFS 2.0.0 에서 PK(정렬) 문제가 있으므로
+  ⇒ WFS 1.1.0 + CQL_INTERSECTS + JSON 출력 방식 사용
+* Polygon → 0.005°(≈550 m) BBOX 타일 분할도 지원
+"""
+
+from __future__ import annotations
+from urllib.parse import urlencode
+from typing import Iterator, List, Tuple
+
+import httpx
+from ..config import settings
+
+# ───────────────────────────────────────────────
+# 공통 상수
+# ───────────────────────────────────────────────
+VWORLD_DOM   = "localhost"
+BASE_WFS     = "https://api.vworld.kr/req/wfs"
+
+# ───────────────────────────────────────────────
+# 1) 소방서 관할 폴리곤 WFS URL
+# ───────────────────────────────────────────────
+def fire_zone_url(ward_name: str) -> str:
+    """lt_c_usfsffb 레이어에서 ward_nm='종로소방서' 형태로 검색"""
+    q = {
+        "service"   : "WFS",
+        "version"   : "2.0.0",
+        "request"   : "GetFeature",
+        "typeName"  : "lt_c_usfsffb",
+        "CQL_FILTER": f"ward_nm='{ward_name}'",
+        "output"    : "json",
+        "srsName"   : "EPSG:4326",
+        "key"       : settings.VWORLD_KEY,
+        "domain"    : VWORLD_DOM,
+    }
+    return f"{BASE_WFS}?{urlencode(q, safe=':,()')}"  # :,() 는 CQL 안에서 필요
+
+# ───────────────────────────────────────────────
+# 2) 건물(dt_d162) WFS URL (※ 1.1.0 + CQL_INTERSECTS)
+# ───────────────────────────────────────────────
+def bldginfo_url(poly_wkt: str) -> str:
+    """
+    dt_d162(건축물대장 요약) 레이어를
+    ① WFS 1.1.0   ② JSON 출력  ③ CQL_INTERSECTS 로 호출
+    => PK 없어서 생기는 2.0.0 오류, 축 혼동 모두 회피
+    """
+    q = {
+        "service"      : "WFS",
+        "version"      : "1.1.0",
+        "request"      : "GetFeature",
+        "typeName"     : "dt_d162",
+        "CQL_FILTER"   : f"INTERSECTS(geom, POLYGON(({poly_wkt})))",
+        "outputFormat" : "application/json",
+        "srsName"      : "EPSG:4326",
+        "maxFeatures"  : 1000,          # 타일 1장당 최대 1000건
+        "key"          : settings.VWORLD_KEY,
+        "domain"       : VWORLD_DOM,
+    }
+    return f"{BASE_WFS}?{urlencode(q, safe=':,() ')}"  # 공백도 허용
+
+# ───────────────────────────────────────────────
+# 3) 폴리곤 외접 BBOX(≈550 m) 타일 제너레이터
+# ───────────────────────────────────────────────
+def split_bbox(poly_coords: List[Tuple[float, float]],
+               step: float = 0.005) -> Iterator[str]:
+    """
+    Parameters
+    ----------
+    poly_coords : [(lon, lat), ...]  # EPSG:4326
+    step        : 0.005° ≈ 550 m (경위도 기준)
+
+    Yields
+    ------
+    str : "lon lat,lon lat,lon lat,lon lat,lon lat"  (닫힌 WKT 링)
+    """
+    lons, lats = zip(*poly_coords)
+    minx, maxx = min(lons), max(lons)
+    miny, maxy = min(lats), max(lats)
+
+    xs = [round(minx + i * step, 6) for i in range(int((maxx - minx) / step) + 1)]
+    ys = [round(miny + i * step, 6) for i in range(int((maxy - miny) / step) + 1)]
+
+    for i in range(len(xs) - 1):
+        for j in range(len(ys) - 1):
+            yield (
+                f"{xs[i]} {ys[j]},{xs[i+1]} {ys[j]},"
+                f"{xs[i+1]} {ys[j+1]},{xs[i]} {ys[j+1]},"
+                f"{xs[i]} {ys[j]}"
+            )
+
+# ───────────────────────────────────────────────
+# 4) HTTP‑GET → JSON 헬퍼
+# ───────────────────────────────────────────────
+async def fetch_json(url: str, client: httpx.AsyncClient):
+    r = await client.get(url, timeout=10.0)
+    r.raise_for_status()
+    return r.json()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -31,3 +31,5 @@ typing-inspection==0.4.1
 typing_extensions==4.14.1
 urllib3==2.5.0
 uvicorn==0.35.0
+shapely[vectorized]==2.1.1
+python-dotenv==1.0.1


### PR DESCRIPTION
# feat: 소방서 관할 내 화재 위험 건물 조회 API 구현
# ✅ 주요 변경 사항

/patrol/buildings?station=소방서명 GET API 구현
→ 소방서 관할 폴리곤 내부의 건물들을 조회해 반환
/chat POST API 구현 { "query": "ㅇㅇ 소방서 화재 예측 지도 그려줘" }
→ 소방서 관할 폴리곤 내부의 건물들을 조회해 반환

# V-World 공공데이터 API 2종 활용:
lt_c_usfsffb: 소방서 관할 구역 (Polygon)
dt_d162: 건물 기본 정보 (2D-Data)

관할 폴리곤 내 건물만 대상으로 위험 점수(riskScore: 0~99점)를 부여해 반환합니다.
응답 구조는 프론트에서 지도 마커 시각화 및 상세 메타데이터 활용에 최적화되어 있습니다.

